### PR TITLE
Fix: Database initialization error due to missing installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network Qml Quick Sql QuickCon
 
 qt_standard_project_setup()
 
+if(COMMAND qt_policy)
+    qt_policy(SET QTP0004 NEW)
+endif()
+
 qt_add_executable(scarlet-launcher
     src/app_window.cpp
     src/app_window.h

--- a/src/app_window.cpp
+++ b/src/app_window.cpp
@@ -13,6 +13,20 @@ namespace scarlet {
 Q_INVOKABLE void AppWindow::appLoaded()
 {
     this->_installationPath = QString(QDir::homePath() + "/.scarlet");
+
+    // Create the installation directory if it doesn't exist
+    // to avoid potential error if the program wants to write to a non-existent
+    // directory
+    QDir installDir(this->_installationPath);
+    if (!installDir.exists()) {
+        if (!installDir.mkpath(".")) {
+            qCritical() << "Failed to create installation directory: " << this->_installationPath;
+            emit statusChanged("Failed to create installation directory");
+            return;
+        }
+        qDebug() << "Created installation directory:" << this->_installationPath;
+    }
+
     this->_latestRelease = scarlet::utils::getLatestGithubRelease("thpatch/thcrap");
     this->_thcrapDownloadURL =
       QString("https://github.com/thpatch/thcrap/releases/download/%1/thcrap.zip")


### PR DESCRIPTION
This PR fixes installation directory creation and subsequently database initialization errors on first run.

## Problem

On first launch, the application would fail with the following message.
```
Failed to open database: "unable to open database file Error opening database"
qt.sql.qsqlquery: QSqlQuery::exec: database not open
qt.sql.qsqlquery: QSqlQuery::exec: database not open
```

This occurred because the `~/.scarlet` directory didn't exist when trying to create the database instance. 

## Solution

The solution is to simply create the installation directory, if not present, before attempting to open the database. Otherwise, this is logged onto stdout. 

Additionally, I have added a CMake flag to set `qt_policy` as well to suppress the configuration warning.